### PR TITLE
Remove ToLower() when parsing a chat command

### DIFF
--- a/Assets/TwitchChatConnect/Scripts/TwitchChatConnect/Data/TwitchChatCommand.cs
+++ b/Assets/TwitchChatConnect/Scripts/TwitchChatConnect/Data/TwitchChatCommand.cs
@@ -12,13 +12,12 @@ namespace TwitchChatConnect.Data
             string[] parameters = message.Split(' ');
 
             Parameters = new string[parameters.Length - 1];
-            Command = parameters[0].ToLower();
+            Command = parameters[0];
 
             for (int i = 1; i < parameters.Length; i++)
             {
                 Parameters[i - 1] = Regex.Replace(parameters[i].ToLower(), "@", "");
             }
-
         }
     }
 }


### PR DESCRIPTION
This change allows the client to differentiate between lower and uppercase.
For instance, if I want to receive the command `!join`, but not the command `!jOiN`, the `.ToLower()` at line 15, isn't going to let me do that. The client might decide whether or not the command should be case sensitive, not the library itself.